### PR TITLE
fix: add default .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PUBLIC_API_ENDPOINT=https://api.animeworld.moe/v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ node_modules
 /build
 /.svelte-kit
 /package
-.env
-.env.*
+.env.*.local
+.env.local
 !.env.example
 .vercel
 .output


### PR DESCRIPTION
Following the standard defined in https://kit.svelte.dev/docs/modules#$env-static-private :
> Note that all environment variables referenced in your code should be declared (for example in an .env file), even if they don't have a value until the app is deployed

it is required to have default `.env` file that contains every environment variables referenced in the codebases.
To override these envs in local environment, create `.env.local` or `env.[mode].local` (e.g: `env.development.local`) in root directory.